### PR TITLE
Add Filter Menu

### DIFF
--- a/iExpense.xcodeproj/project.pbxproj
+++ b/iExpense.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		843404DE2C645E710008633E /* ExpensesViewP1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843404DD2C645E710008633E /* ExpensesViewP1.swift */; };
 		843404E02C645ECD0008633E /* SortEnumP1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843404DF2C645ECD0008633E /* SortEnumP1.swift */; };
+		843404E22C6467500008633E /* FilterEnumP1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843404E12C6467500008633E /* FilterEnumP1.swift */; };
 		845A025A2BA5488800D8D75E /* iExpenseApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845A02592BA5488800D8D75E /* iExpenseApp.swift */; };
 		845A025C2BA5488800D8D75E /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845A025B2BA5488800D8D75E /* ContentView.swift */; };
 		845A025E2BA5488D00D8D75E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 845A025D2BA5488D00D8D75E /* Assets.xcassets */; };
@@ -32,6 +33,7 @@
 /* Begin PBXFileReference section */
 		843404DD2C645E710008633E /* ExpensesViewP1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpensesViewP1.swift; sourceTree = "<group>"; };
 		843404DF2C645ECD0008633E /* SortEnumP1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortEnumP1.swift; sourceTree = "<group>"; };
+		843404E12C6467500008633E /* FilterEnumP1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterEnumP1.swift; sourceTree = "<group>"; };
 		845A02562BA5488800D8D75E /* iExpense.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iExpense.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		845A02592BA5488800D8D75E /* iExpenseApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iExpenseApp.swift; sourceTree = "<group>"; };
 		845A025B2BA5488800D8D75E /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -110,6 +112,7 @@
 				845A03522C3622A000D8D75E /* ExpenseItemPractice1.swift */,
 				845A03542C36241D00D8D75E /* ExpenseCategory.swift */,
 				843404DF2C645ECD0008633E /* SortEnumP1.swift */,
+				843404E12C6467500008633E /* FilterEnumP1.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -213,6 +216,7 @@
 				845A026C2BA554F700D8D75E /* DeleteItems_onDelete.swift in Sources */,
 				845A03572C36296200D8D75E /* AddViewPractice1.swift in Sources */,
 				845A025C2BA5488800D8D75E /* ContentView.swift in Sources */,
+				843404E22C6467500008633E /* FilterEnumP1.swift in Sources */,
 				845A02702BA575ED00D8D75E /* CodableDataStorage.swift in Sources */,
 				845A03532C3622A000D8D75E /* ExpenseItemPractice1.swift in Sources */,
 				845A026E2BA5708600D8D75E /* UserDefaults.swift in Sources */,

--- a/iExpense/Model/ExpenseItemPractice1.swift
+++ b/iExpense/Model/ExpenseItemPractice1.swift
@@ -15,10 +15,17 @@ class ExpenseItemPractice1 {
     let name: String
     let price: Double
     let category: ExpenseCategory
+    let categoryString: String
     
     init(name: String, price: Double, category: ExpenseCategory) {
         self.name = name
         self.price = price
         self.category = category
+        switch category {
+            case .Business:
+                categoryString = "Business"
+            case .Personal:
+                categoryString = "Personal"
+        }
     }
 }

--- a/iExpense/Model/FilterEnumP1.swift
+++ b/iExpense/Model/FilterEnumP1.swift
@@ -1,0 +1,14 @@
+//
+//  FilterEnumP1.swift
+//  iExpense
+//
+//  Created by Fernando Callejas on 07/08/24.
+//
+
+import Foundation
+
+enum FilterEnumP1: String, CaseIterable {
+    case all = "All"
+    case business = "Business"
+    case personal = "Personal"
+}

--- a/iExpense/View/ExpensesViewP1.swift
+++ b/iExpense/View/ExpensesViewP1.swift
@@ -13,18 +13,35 @@ struct ExpensesViewP1: View {
     
     @Query private var expenses: [ExpenseItemPractice1]
     
-    init(sortBy: SortEnumP1) {
+    init(sortBy: SortEnumP1, filterEnum: FilterEnumP1) {
+        var sortDesciptor: [SortDescriptor<ExpenseItemPractice1>]
+        
         if sortBy == .amount {
-            _expenses = Query(sort: [
+             sortDesciptor = [
                 SortDescriptor(\ExpenseItemPractice1.price, order: .reverse),
                 SortDescriptor(\ExpenseItemPractice1.name, order: .forward)
-            ])
+            ]
         } else {
-            _expenses = Query(sort: [
+            sortDesciptor = [
                 SortDescriptor(\ExpenseItemPractice1.name, order: .forward),
                 SortDescriptor(\ExpenseItemPractice1.price, order: .reverse)
-            ])
+            ]
         }
+        
+        if filterEnum == FilterEnumP1.all {
+            _expenses = Query(filter: #Predicate<ExpenseItemPractice1> { expense in
+                expense.categoryString == "Business" || expense.categoryString == "Personal"
+            }, sort: sortDesciptor)
+        } else if filterEnum == FilterEnumP1.business {
+            _expenses = Query(filter: #Predicate<ExpenseItemPractice1> { expense in
+                expense.categoryString == "Business"
+            }, sort: sortDesciptor)
+        } else if filterEnum == FilterEnumP1.personal {
+            _expenses = Query(filter: #Predicate<ExpenseItemPractice1> { expense in
+                expense.categoryString == "Personal"
+            }, sort: sortDesciptor)
+        }
+        
     }
     
     var body: some View {
@@ -59,5 +76,5 @@ struct ExpensesViewP1: View {
 }
 
 #Preview {
-    ExpensesViewP1(sortBy: SortEnumP1.amount)
+    ExpensesViewP1(sortBy: SortEnumP1.amount, filterEnum: FilterEnumP1.all)
 }

--- a/iExpense/View/Practice1.swift
+++ b/iExpense/View/Practice1.swift
@@ -7,7 +7,6 @@
 
 import SwiftData
 import SwiftUI
-//import Observation
 
 struct Practice1: View {
     @Environment(\.modelContext) var modelContext
@@ -16,10 +15,11 @@ struct Practice1: View {
     @State private var showsAddNewItem = false
     @State private var pathStore = P1PathStore()
     @State private var expensesOrder = SortEnumP1.name
+    @State private var filterExpenses = FilterEnumP1.all
 
     var body: some View {
         NavigationStack(path: $pathStore.path) {
-            ExpensesViewP1(sortBy: expensesOrder)
+            ExpensesViewP1(sortBy: expensesOrder, filterEnum: filterExpenses)
                 .navigationTitle("iExpense")
                 .toolbar {
                     ToolbarItem {
@@ -34,6 +34,15 @@ struct Practice1: View {
                                     .tag(SortEnumP1.name)
                                 Text("Amount")
                                     .tag(SortEnumP1.amount)
+                            }
+                        }
+                    }
+                    ToolbarItem {
+                        Menu("Filter Expenses", systemImage: "loupe") {
+                            Picker("Filter", selection: $filterExpenses) {
+                                ForEach(FilterEnumP1.allCases, id: \.self) { filterCase in
+                                    Text(filterCase.rawValue)
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Add filter menu to enable user to only show Personal or Business expenses On the initializer of expenses view was added the creation of different querys to replace existing depending of if predicate should allow only Personal, only Business or both type of expenses A Filter Enumeration was added to determine the filter to use A new property was added to ExpenseItem class to allow predicate to compare the category